### PR TITLE
Update openTabsWhere_whichTabSelectWhenCloseTab.uc.js

### DIFF
--- a/openTabsWhere_whichTabSelectWhenCloseTab.uc.js
+++ b/openTabsWhere_whichTabSelectWhenCloseTab.uc.js
@@ -336,7 +336,7 @@
     if( prefWHERE != "FARRIGHT") {
       debug("*LINKONLYNEXT/NEXT asLlink=" + asLinkPosition() +" || "+ (prefWHERE != "LINKONLYNEXT") );
       if( (prefWHERE != "LINKONLYNEXT" || asLinkPosition()) ){
-        var pTab = this.mCurrentTab;
+        var pTab = gBrowser.mCurrentTab;
         aTabpos = ((getPref("userChrome.openTabsWhere.INCREMENT", "int", INCREMENT)==1)?getMostRightChildTab(pTab):pTab)._tPos + 1;
 
         if (aTabpos != aTab._tPos) {
@@ -541,7 +541,7 @@
             var pTab = mTabChilds[i];
             if(pTab.hasAttribute("Olinkedpanel")
                && pTab.getAttribute("Olinkedpanel").indexOf(Plinkedpanel) > -1){
-              gBrowser.mCurrentTab = pTab;
+              gBrowser.selectedTab = pTab;
               return;
             }
           }


### PR DESCRIPTION
Hi.
Thank you for cool scripts.

On Firefox10.0.1 (and other recently version), it seems openTabsWhere_whichTabSelectWhenCloseTab.uc.js don't set Plinkedpanel and Olinkedpanel attributes correctly. I changed line 339 to set parrent tab, and line 544 to select it when tab closed. I'm not too sure, but this can work.
