### PR TITLE
Fix closedTabsPopup of MouseGestures2_e10s.uc.js

### DIFF
--- a/95/MouseGestures2_e10s.uc.js
+++ b/95/MouseGestures2_e10s.uc.js
@@ -1359,7 +1359,7 @@ let ucjsMouseGestures_helper = {
       undoPopup.appendChild(document.createXULElement("menuseparator"));
 
       // populate menu
-      let undoItems = eval("(" + ss.getClosedTabData(window) + ")");
+      let undoItems = ss.getClosedTabData(window);
       for (let i = 0; i < undoItems.length; i++) {
         var entries = undoItems[i].state.entries;
         var tooltiptext = "";


### PR DESCRIPTION
According to Bug 1733425, SessionStore.getClosedTabData now returns an object instead of a JSON string.

https://bugzilla.mozilla.org/show_bug.cgi?id=1733425